### PR TITLE
netty-common dependency upgrade due to CVE-2024-47535.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
+		<!-- https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-8367012 -->
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-common</artifactId>
+			<version>4.1.115.Final</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-gateway</artifactId>


### PR DESCRIPTION
Fore more information please visit : https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-8367012